### PR TITLE
feat(request-dumper): handle read error gracefully

### DIFF
--- a/dumper.go
+++ b/dumper.go
@@ -72,8 +72,8 @@ func (d *BodyDumper) DumpBody(next fox.HandlerFunc) fox.HandlerFunc {
 			_, err := buf.ReadFrom(c.Request().Body)
 			if err != nil {
 				log.Println("body dumper: unexpected error while reading request body")
-				next(c)
-				return
+				buf.Reset()
+				goto RespFallback
 			}
 
 			cpBuf := p.Get().(*bytes.Buffer)
@@ -89,6 +89,7 @@ func (d *BodyDumper) DumpBody(next fox.HandlerFunc) fox.HandlerFunc {
 			c.Request().Body = nopCloser{cpBuf}
 		}
 
+	RespFallback:
 		if d.res != nil {
 			c.TeeWriter(buf)
 			next(c)

--- a/dumper.go
+++ b/dumper.go
@@ -1,3 +1,7 @@
+// Copyright 2023 Sylvain Müller. All rights reserved.
+// Mount of this source code is governed by a MIT license that can be found
+// at https://github.com/tigerwill90/foxdump/blob/master/LICENSE.txt.
+
 package foxdump
 
 import (

--- a/dumper.go
+++ b/dumper.go
@@ -84,7 +84,7 @@ func (d *BodyDumper) DumpBody(next fox.HandlerFunc) fox.HandlerFunc {
 			cpBuf.Reset()
 			defer p.Put(cpBuf)
 
-			// Safe as Buffer.Writer make a copy of p
+			// Safe as Buffer.Write make a copy of p
 			cpBuf.Write(buf.Bytes())
 
 			d.req(c, buf.Bytes())

--- a/dumper_test.go
+++ b/dumper_test.go
@@ -1,3 +1,7 @@
+// Copyright 2023 Sylvain Müller. All rights reserved.
+// Mount of this source code is governed by a MIT license that can be found
+// at https://github.com/tigerwill90/foxdump/blob/master/LICENSE.txt.
+
 package foxdump
 
 import (

--- a/dumper_test.go
+++ b/dumper_test.go
@@ -3,6 +3,7 @@ package foxdump
 import (
 	"bytes"
 	"crypto/rand"
+	"errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tigerwill90/fox"
@@ -28,6 +29,12 @@ func (m *mockResponseWriter) WriteString(s string) (n int, err error) {
 
 func (m *mockResponseWriter) WriteHeader(int) {}
 
+type errorReader struct{}
+
+func (r *errorReader) Read(p []byte) (n int, err error) {
+	return n, errors.New("error")
+}
+
 type repeatReader struct {
 	data []byte
 	eof  bool
@@ -44,6 +51,12 @@ func (r *repeatReader) Read(p []byte) (n int, err error) {
 }
 
 func (r *repeatReader) Close() error { return nil }
+
+var failBodyHandler = func(t *testing.T, want []byte) BodyHandler {
+	return func(c fox.Context, buf []byte) {
+		t.Error("should not be call")
+	}
+}
 
 func BenchmarkFoxDumpMiddleware(b *testing.B) {
 	f := fox.New(fox.WithMiddleware(Middleware(func(c fox.Context, buf []byte) {
@@ -140,11 +153,6 @@ func TestBodyDumper_DumpBody(t *testing.T) {
 }
 
 func TestWithFilter(t *testing.T) {
-	var failBodyHandler = func(t *testing.T, want []byte) BodyHandler {
-		return func(c fox.Context, buf []byte) {
-			t.Error("should not be call")
-		}
-	}
 
 	cases := []struct {
 		name   string
@@ -195,4 +203,23 @@ func TestWithFilter(t *testing.T) {
 			assert.Equal(t, buf, w.Body.Bytes())
 		})
 	}
+}
+
+func TestBodyDumper_DumpBodyFallback(t *testing.T) {
+	buf := make([]byte, 1*1024*1024)
+	_, err := rand.Read(buf)
+	require.NoError(t, err)
+
+	f := fox.New(fox.WithMiddleware(Middleware(failBodyHandler(t, nil), func(c fox.Context, dump []byte) {
+		assert.Equal(t, buf, dump)
+	})))
+
+	require.NoError(t, f.Handle(http.MethodPost, "/foo", func(c fox.Context) {
+		assert.NoError(t, c.Blob(http.StatusOK, fox.MIMEOctetStream, buf))
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/foo", new(errorReader))
+	w := httptest.NewRecorder()
+	f.ServeHTTP(w, req)
+	assert.Equal(t, buf, w.Body.Bytes())
 }

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/stretchr/testify v1.8.2
-	github.com/tigerwill90/fox v0.9.2
+	github.com/tigerwill90/fox v0.9.3
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/stretchr/testify v1.8.2
-	github.com/tigerwill90/fox v0.9.3
+	github.com/tigerwill90/fox v0.10.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/tigerwill90/fox v0.9.3 h1:iDtNIQRPpqvIjSljvX6UVO2XIFtIqYPiOXGwCjuq3iM=
-github.com/tigerwill90/fox v0.9.3/go.mod h1:frBRK49d4TXcELy3911opGU3RZQSUq++BHQUwhykpQw=
+github.com/tigerwill90/fox v0.10.0 h1:6E+rJYLF79wuc+RAMUggotGtO1e4TdcjjKG6n4q6TCk=
+github.com/tigerwill90/fox v0.10.0/go.mod h1:frBRK49d4TXcELy3911opGU3RZQSUq++BHQUwhykpQw=
 golang.org/x/net v0.10.0 h1:X2//UzNDwYmtCLn7To6G58Wr6f5ahEAQgKNzv9Y951M=
 golang.org/x/text v0.9.0 h1:2sjJmO8cDvYveuX97RDLsxlyUxLl+GHoLxBiRdHllBE=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/tigerwill90/fox v0.9.2 h1:ihi9hyeo8Vb2z+sW0xd3syuBucw99RVtLNBbe77kYko=
-github.com/tigerwill90/fox v0.9.2/go.mod h1:frBRK49d4TXcELy3911opGU3RZQSUq++BHQUwhykpQw=
+github.com/tigerwill90/fox v0.9.3 h1:iDtNIQRPpqvIjSljvX6UVO2XIFtIqYPiOXGwCjuq3iM=
+github.com/tigerwill90/fox v0.9.3/go.mod h1:frBRK49d4TXcELy3911opGU3RZQSUq++BHQUwhykpQw=
 golang.org/x/net v0.10.0 h1:X2//UzNDwYmtCLn7To6G58Wr6f5ahEAQgKNzv9Y951M=
 golang.org/x/text v0.9.0 h1:2sjJmO8cDvYveuX97RDLsxlyUxLl+GHoLxBiRdHllBE=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/options.go
+++ b/options.go
@@ -1,3 +1,7 @@
+// Copyright 2023 Sylvain Müller. All rights reserved.
+// Mount of this source code is governed by a MIT license that can be found
+// at https://github.com/tigerwill90/foxdump/blob/master/LICENSE.txt.
+
 package foxdump
 
 import "net/http"


### PR DESCRIPTION
This PR refines the error handling procedure of the BodyDumper middleware. Instead of halting the middleware chain upon encountering an error while dumping the request body, the updated implementation ensures that the subsequent handler is invoked and an error log is emitted. Moreover, the middleware can now proceed to dump the response body even when an error occurs during the request body dump. Here's the relevant code snippet:

````go
func (d *BodyDumper) DumpBody(next fox.HandlerFunc) fox.HandlerFunc {
    // ...
    if d.req != nil {
        _, err := buf.ReadFrom(c.Request().Body)
        if err != nil {
            log.Println("body dumper: unexpected error while reading request body")
            buf.Reset()
            goto RespFallback
        }
        // ...
    }

RespFallback:
    if d.res != nil {
        c.TeeWriter(buf)
        next(c)
        d.res(c, buf.Bytes())
        return
    }
    next(c)
}
````

This approach enhances the resilience of the middleware, allowing the continuation of the request-response cycle and providing more insightful logging for error tracking.